### PR TITLE
allow top ribbons be position:fixed too

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -59,6 +59,10 @@
   top: 0;
 }
 
+.github-fork-ribbon-wrapper.fixed {
+  position: fixed;
+}
+
 .github-fork-ribbon-wrapper.left {
   left: 0;
 }


### PR DESCRIPTION
just add the "fixed" class to your wrapper and the ribbon will be fixed
(or static) in the corner, not scrolling away.

Fixes: #11
