### PR TITLE
set the style of a:hover explicitely

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -25,7 +25,8 @@
   z-index: 9999;
 }
 
-.github-fork-ribbon a {
+.github-fork-ribbon a,
+.github-fork-ribbon a:hover {
   /* Set the font */
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;


### PR DESCRIPTION
if not set, the ribbon will inherit the hover style from (e.g., if used)
twitter bootstrap and become funny blue-ish and not as we want it.
