### PR TITLE
set z-index on the ribbon wrapper too

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -58,6 +58,7 @@
   position: absolute;
   overflow: hidden;
   top: 0;
+  z-index: 9999;
 }
 
 .github-fork-ribbon-wrapper.fixed {


### PR DESCRIPTION
when using a fixed ribbon and a fixed bootstrap navbar, the ribbon is below
the navbar, despite having z-index:9999. setting the z-index on the wrapper
fixes this issue.

this does not happen when using position:absolute.

you can see these two in action at https://qifi.org, btw :)
