### PR TITLE
Use CSS standard declaration for the linear gradient on line 18

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -15,7 +15,7 @@
   background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
   background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
   background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
-  background-image: linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
 
   /* Add a drop shadow */
   -webkit-box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Firstly, this is kind of trivial, sorry for that, I love your CSS ribbon and I suppose I'm "building a shed" here but pressing on regardless...

So I was browsing a web site using Firefox that used your fork me on github ribbon and I noticed that I got CSS errors on lines 13, 14, 16, 17 and 18 of the gh-fork-ribbon.css file.  Looking at the file I see that you're handling all the browser variations and that, since I was using Firefox, the one that matched was line 15 (-moz-linear etc).  So I was about to not worry about it since that is fine, of course, but the last error concerned me (line 18), specifically the error was:

```
Expected color but found 'top'.  Error in parsing value for 'background-image'.  Declaration dropped.
```

So, I think your intention was that this should be the CSS standard approach but I think it is not quite correct (not that it really matters as I think every browser will just pick one of the preceeding background images regardless - I said this was trivial right?).  Looking at the [Linear Gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) documentation I notice that the syntax is:

```
linear-gradient(  [ <angle> | to <side-or-corner> ,]? <color-stop> [, <color-stop>]+ )
```

So I think that that line should be changed to what I attach here as a pull request, specifically:

```
background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
```

This will make the gradient from the top to the bottom, completely transparent to slightly transparent black as per your comment in said file.
