### PR TITLE
Add license comments

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -1,3 +1,8 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.1.0 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
 /* Left will inherit from right (so we don't need to duplicate code) */
 .github-fork-ribbon {
   /* The right and left classes determine the side we attach our banner to */

--- a/gh-fork-ribbon.ie.css
+++ b/gh-fork-ribbon.ie.css
@@ -1,3 +1,8 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.1.0 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
 /* IE voodoo courtesy of http://stackoverflow.com/a/4617511/263871 and
  * http://www.useragentman.com/IETransformsTranslator */
 


### PR DESCRIPTION
When we use CSS compressors such as [clean-css](https://github.com/GoalSmashers/clean-css), we can preserve license comments wrapped with `/*! ... */`.
