### PR TITLE
Put IE9 CDN CSS in conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ in CSS, hence resolution-independent.
 CDN provided by [cdnjs](https://cdnjs.com/libraries/github-fork-ribbon-css)
 ```
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
+<!--[if lt IE 9]>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
+<![endif]-->
 ```
 
 See 'em in action! <http://simonwhitaker.github.io/github-fork-ribbon-css/>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Fork me on Github CSS Ribbon</title>
+    <title>Fork me on GitHub CSS Ribbon</title>
     <link rel="stylesheet" href="//oss.maxcdn.com/libs/normalize-css/3.0.0/normalize.min.css">
     <style>
         /* This is just the styling for this page. See below for the CSS for the ribbon itself. */
@@ -104,7 +104,9 @@
         </p>
         <code>
           &lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" /&gt;<br/>
-          &lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" /&gt;
+          &lt;!--[if lt IE 9]&gt;<br/>
+              &nbsp;&nbsp;&lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" /&gt;<br/>
+          &lt;![endif]--&gt;
         </code>
 
         <h2>About</h2>


### PR DESCRIPTION
The example CDN code shows doesn't have the IE9 CSS file inside a conditional:

``` html
<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
```

This causes the ribbons to be mislaid if just copying and pasting, see #37.

Instead, add a conditional around the example code to prevent copy/paste errors:

``` html
<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
<!--[if lt IE 9]>
    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
<![endif]-->
```

Fixes #37.

Also fixes a "Github" -> "GitHub" typo.
