### PR TITLE
Update gh-fork-ribbon.css

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -1,5 +1,5 @@
 /*!
- * "Fork me on GitHub" CSS ribbon v0.1.1 | MIT License
+ * "Fork me on GitHub" CSS ribbon v0.1.2 | MIT License
  * https://github.com/simonwhitaker/github-fork-ribbon-css
 */
 
@@ -15,16 +15,10 @@
   background-color: #a00;
 
   /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
-  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
   background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
-  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
-  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
-  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
   background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
 
   /* Add a drop shadow */
-  -webkit-box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
-  -moz-box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
 
   /* Set the font */
@@ -98,11 +92,9 @@
   top: 42px;
   right: -43px;
 
-  -webkit-transform: rotate(45deg);
-  -moz-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  -o-transform: rotate(45deg);
-  transform: rotate(45deg);
+  -webkit-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
 .github-fork-ribbon-wrapper.left .github-fork-ribbon {
@@ -110,9 +102,7 @@
   left: -43px;
 
   -webkit-transform: rotate(-45deg);
-  -moz-transform: rotate(-45deg);
   -ms-transform: rotate(-45deg);
-  -o-transform: rotate(-45deg);
   transform: rotate(-45deg);
 }
 
@@ -120,12 +110,10 @@
 .github-fork-ribbon-wrapper.left-bottom .github-fork-ribbon {
   top: 80px;
   left: -43px;
-
-  -webkit-transform: rotate(45deg);
-  -moz-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  -o-transform: rotate(45deg);
-  transform: rotate(45deg);
+  
+  -webkit-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
 .github-fork-ribbon-wrapper.right-bottom .github-fork-ribbon {
@@ -133,8 +121,6 @@
   right: -43px;
 
   -webkit-transform: rotate(-45deg);
-  -moz-transform: rotate(-45deg);
   -ms-transform: rotate(-45deg);
-  -o-transform: rotate(-45deg);
   transform: rotate(-45deg);
 }


### PR DESCRIPTION
Theres some vendor prefixes that is not needed anymore:

linear gradients only -webit- for old android: http://caniuse.com/#search=linear-gradient
box shadow: http://caniuse.com/#search=box-shadow
transform only need -ms- for IE9 webkit for everyone else: http://caniuse.com/#search=transform
