### PR TITLE
Example should use https

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,9 @@
             Copy the following code into the <strong>&lt;head&gt;</strong> of your page:
         </p>
         <code>
-          &lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" /&gt;<br/>
+          &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" /&gt;<br/>
           &lt;!--[if lt IE 9]&gt;<br/>
-              &nbsp;&nbsp;&lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" /&gt;<br/>
+              &nbsp;&nbsp;&lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" /&gt;<br/>
           &lt;![endif]--&gt;
         </code>
         <p>


### PR DESCRIPTION
If https should be used where possible (see #44) then so should the copy-and-pastable example at:

https://simonwhitaker.github.io/github-fork-ribbon-css/
