### PR TITLE
Complete example, update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Copy the following code into the `<head>` of your page:
 
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
 <!--[if lt IE 9]>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
 <![endif]-->
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,22 @@ in CSS, hence resolution-independent.
 
 ## Using "Fork me on GitHub" CSS ribbon with a CDN
 
-CDN provided by [cdnjs](https://cdnjs.com/libraries/github-fork-ribbon-css)
+You can use github-fork-ribbon-css without installation via [cdnjs.com](https://cdnjs.com/libraries/github-fork-ribbon-css).
+
+Copy the following code into the `<head>` of your page:
+
 
 ```html
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css" />
 <!--[if lt IE 9]>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.ie.min.css" />
 <![endif]-->
+```
+
+And this into the `<body>` of your page:
+
+```html
+<a class="github-fork-ribbon" href="http://url.to-your.repo" title="Fork me on GitHub">Fork me on GitHub</a>
 ```
 
 See 'em in action! <https://simonwhitaker.github.io/github-fork-ribbon-css/>


### PR DESCRIPTION
It'd be handy to have copy-n-pastable snippets of code for both `<head>` and `<body>` in the README, like in index.html, not just `<head>`.

I also updated the version from 0.1.1 to 0.2.0, to match index.html.

However, I noticed [cdnjs doesn't yet have 0.2.0, only 0.1.0 and 0.1.1](https://cdnjs.com/libraries/github-fork-ribbon-css). It should be released, so these new links in the README and the old ones in index.html work.
