### PR TITLE
add box-sizing: content-box

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -31,6 +31,10 @@
   top: 3.23em;
   right: -3.23em;
   
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
   -ms-transform: rotate(45deg);


### PR DESCRIPTION
Bootstrap sets `box-sizing: border-box;` for all `:after` and `:before` blocks. This causes the ribbon to render incorrectly. This commit resets the `box-sizing` to `content-box` the default value for this attribute.

without this PR:
![image](https://cloud.githubusercontent.com/assets/204013/14040570/aced91b4-f268-11e5-90a1-0b22a15e9bf1.png)

with this PR:
![image](https://cloud.githubusercontent.com/assets/204013/14040578/c5ed91a0-f268-11e5-8bbd-1a3745805060.png)
