### PR TITLE
github-fork-ribbon: Use transparent background for hover

### DIFF
--- a/gh-fork-ribbon.css
+++ b/gh-fork-ribbon.css
@@ -21,6 +21,10 @@
   position: fixed;
 }
 
+.github-fork-ribbon:hover, .github-fork-ribbon:active {
+  background-color: rgba(0, 0, 0, 0.0);
+}
+
 .github-fork-ribbon:before, .github-fork-ribbon:after {
   /* The right and left classes determine the side we attach our banner to */
   position: absolute;


### PR DESCRIPTION
Otherwise one gets a colored box while hovering/active

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>